### PR TITLE
Update to muka/go-bluetooth@bluez-5.66 (closes #1)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.1 // indirect
 	github.com/miekg/dns v1.1.46 // indirect
-	github.com/muka/go-bluetooth v0.0.0-20211227071625-1c7f8793aa7e // indirect
+	github.com/muka/go-bluetooth v0.0.0-20221213043735-5c782bb62e81 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -173,6 +173,8 @@ github.com/modern-go/reflect2 v1.0.1/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3Rllmb
 github.com/modern-go/reflect2 v1.0.2/go.mod h1:yWuevngMOJpCy52FWWMvUC8ws7m/LJsjYzDa0/r8luk=
 github.com/muka/go-bluetooth v0.0.0-20211227071625-1c7f8793aa7e h1:1hynBmSjZTk2XdeehqkVW8gPEDVhuXZHftZTO8WhgMs=
 github.com/muka/go-bluetooth v0.0.0-20211227071625-1c7f8793aa7e/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
+github.com/muka/go-bluetooth v0.0.0-20221213043735-5c782bb62e81 h1:VwzHPy3T4iTpuJjWFeNw2dQFXLkT7dt/5RfyBYh0XEg=
+github.com/muka/go-bluetooth v0.0.0-20221213043735-5c782bb62e81/go.mod h1:dMCjicU6vRBk34dqOmIZm0aod6gUwZXOXzBROqGous0=
 github.com/mwitkow/go-conntrack v0.0.0-20161129095857-cc309e4a2223/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRWi+5nqEBWmkhHvq77mSJWrCKwh8bxhgT7d/eI7P4U=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=


### PR DESCRIPTION
This seems to prevent the "MapToStruct: Field not found: Bonded" errors with bluez 5.66 (see issue #1 for more info).